### PR TITLE
NO-ISSUE - Add CA retrieve option

### DIFF
--- a/api/http/endpoint.go
+++ b/api/http/endpoint.go
@@ -67,7 +67,7 @@ func downloadCertEndpoint(svc certs.Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (response interface{}, err error) {
 		req := request.(downloadReq)
 		if err := req.validate(); err != nil {
-			return downloadCertRes{}, err
+			return fileDownloadRes{}, err
 		}
 		cert, ca, err := svc.RetrieveCert(ctx, req.token, req.id)
 		if err != nil {
@@ -240,6 +240,57 @@ func generateCRLEndpoint(svc certs.Service) endpoint.Endpoint {
 
 		return crlRes{
 			CrlBytes: crlBytes,
+		}, nil
+	}
+}
+
+func getDownloadCATokenEndpoint(svc certs.Service) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (response interface{}, err error) {
+		token, err := svc.RetrieveCertDownloadToken(ctx)
+		if err != nil {
+			return requestCertDownloadTokenRes{}, err
+		}
+
+		return requestCertDownloadTokenRes{Token: token}, nil
+	}
+}
+
+func downloadCAEndpoint(svc certs.Service) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (response interface{}, err error) {
+		req := request.(downloadReq)
+		if err := req.validate(); err != nil {
+			return fileDownloadRes{}, err
+		}
+
+		cert, err := svc.GetSigningCA(ctx, req.token)
+		if err != nil {
+			return fileDownloadRes{}, err
+		}
+
+		return fileDownloadRes{
+			Certificate: cert.Certificate,
+			PrivateKey:  cert.Key,
+			Filename:    "ca.zip",
+			ContentType: "application/zip",
+		}, nil
+	}
+}
+
+func viewCAEndpoint(svc certs.Service) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (response interface{}, err error) {
+		req := request.(downloadReq)
+		if err := req.validate(); err != nil {
+			return viewCertRes{}, err
+		}
+
+		cert, err := svc.GetSigningCA(ctx, req.token)
+		if err != nil {
+			return viewCertRes{}, err
+		}
+
+		return viewCertRes{
+			Certificate: string(cert.Certificate),
+			Key:         string(cert.Key),
 		}, nil
 	}
 }

--- a/api/http/endpoint.go
+++ b/api/http/endpoint.go
@@ -246,7 +246,7 @@ func generateCRLEndpoint(svc certs.Service) endpoint.Endpoint {
 
 func getDownloadCATokenEndpoint(svc certs.Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (response interface{}, err error) {
-		token, err := svc.RetrieveCertDownloadToken(ctx)
+		token, err := svc.RetrieveCAToken(ctx)
 		if err != nil {
 			return requestCertDownloadTokenRes{}, err
 		}

--- a/api/http/requests.go
+++ b/api/http/requests.go
@@ -15,9 +15,6 @@ type downloadReq struct {
 }
 
 func (req downloadReq) validate() error {
-	if req.id == "" {
-		return errors.Wrap(certs.ErrMalformedEntity, ErrEmptySerialNo)
-	}
 	if req.token == "" {
 		return errors.Wrap(certs.ErrMalformedEntity, ErrEmptyToken)
 	}

--- a/api/http/responses.go
+++ b/api/http/responses.go
@@ -75,24 +75,6 @@ func (res requestCertDownloadTokenRes) Empty() bool {
 	return false
 }
 
-type downloadCertRes struct {
-	Certificate []byte `json:"certificate"`
-	PrivateKey  []byte `json:"private_key"`
-	CA          []byte `json:"ca"`
-}
-
-func (res downloadCertRes) Code() int {
-	return http.StatusOK
-}
-
-func (res downloadCertRes) Headers() map[string]string {
-	return map[string]string{}
-}
-
-func (res downloadCertRes) Empty() bool {
-	return false
-}
-
 type issueCertRes struct {
 	SerialNumber string    `json:"serial_number"`
 	Certificate  string    `json:"certificate,omitempty"`

--- a/api/http/responses.go
+++ b/api/http/responses.go
@@ -138,12 +138,12 @@ func (res listCertsRes) Empty() bool {
 }
 
 type viewCertRes struct {
-	SerialNumber string    `json:"serial_number"`
+	SerialNumber string    `json:"serial_number,omitempty"`
 	Certificate  string    `json:"certificate,omitempty"`
-	Key          string    `json:"key,omitempty"`
-	Revoked      bool      `json:"revoked"`
-	ExpiryTime   time.Time `json:"expiry_time"`
-	EntityID     string    `json:"entity_id"`
+	Key          string    `json:"key,omitempty,omitempty"`
+	Revoked      bool      `json:"revoked,omitempty"`
+	ExpiryTime   time.Time `json:"expiry_time,omitempty"`
+	EntityID     string    `json:"entity_id,omitempty"`
 }
 
 func (res viewCertRes) Code() int {

--- a/api/logging.go
+++ b/api/logging.go
@@ -61,16 +61,16 @@ func (lm *loggingMiddleware) RevokeCert(ctx context.Context, serialNumber string
 	return lm.svc.RevokeCert(ctx, serialNumber)
 }
 
-func (lm *loggingMiddleware) RetrieveCertDownloadToken(ctx context.Context, serialNumber string) (tokenString string, err error) {
+func (lm *loggingMiddleware) RetrieveCertDownloadToken(ctx context.Context, serialNumber ...string) (tokenString string, err error) {
 	defer func(begin time.Time) {
-		message := fmt.Sprintf("Method get_cert_download_token for cert %s took %s to complete", serialNumber, time.Since(begin))
+		message := fmt.Sprintf("Method get_cert_download_token for cert took %s to complete", time.Since(begin))
 		if err != nil {
 			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
 			return
 		}
 		lm.logger.Info(message)
 	}(time.Now())
-	return lm.svc.RetrieveCertDownloadToken(ctx, serialNumber)
+	return lm.svc.RetrieveCertDownloadToken(ctx, serialNumber...)
 }
 
 func (lm *loggingMiddleware) IssueCert(ctx context.Context, entityID, ttl string, ipAddrs []string, options certs.SubjectOptions) (cert certs.Certificate, err error) {
@@ -97,7 +97,7 @@ func (lm *loggingMiddleware) ListCerts(ctx context.Context, pm certs.PageMetadat
 	return lm.svc.ListCerts(ctx, pm)
 }
 
-func (lm *loggingMiddleware) ViewCert(ctx context.Context, serialNumber string) (cert certs.Certificate, err error) {
+func (lm *loggingMiddleware) ViewCert(ctx context.Context, serialNumber ...string) (cert certs.Certificate, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method view_cert for serial number %s took %s to complete", serialNumber, time.Since(begin))
 		if err != nil {
@@ -106,7 +106,7 @@ func (lm *loggingMiddleware) ViewCert(ctx context.Context, serialNumber string) 
 		}
 		lm.logger.Info(message)
 	}(time.Now())
-	return lm.svc.ViewCert(ctx, serialNumber)
+	return lm.svc.ViewCert(ctx, serialNumber...)
 }
 
 func (lm *loggingMiddleware) OCSP(ctx context.Context, serialNumber string) (cert *certs.Certificate, ocspStatus int, rootCACert *x509.Certificate, err error) {
@@ -143,4 +143,16 @@ func (lm *loggingMiddleware) GenerateCRL(ctx context.Context, caType certs.CertT
 		lm.logger.Info(message)
 	}(time.Now())
 	return lm.svc.GenerateCRL(ctx, caType)
+}
+
+func (lm *loggingMiddleware) GetSigningCA(ctx context.Context, token string) (cert certs.Certificate, err error) {
+	defer func(begin time.Time) {
+		message := fmt.Sprintf("Method get_signing_ca took %s to complete", time.Since(begin))
+		if err != nil {
+			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
+			return
+		}
+		lm.logger.Info(message)
+	}(time.Now())
+	return lm.svc.GetSigningCA(ctx, token)
 }

--- a/api/logging.go
+++ b/api/logging.go
@@ -61,7 +61,7 @@ func (lm *loggingMiddleware) RevokeCert(ctx context.Context, serialNumber string
 	return lm.svc.RevokeCert(ctx, serialNumber)
 }
 
-func (lm *loggingMiddleware) RetrieveCertDownloadToken(ctx context.Context, serialNumber ...string) (tokenString string, err error) {
+func (lm *loggingMiddleware) RetrieveCertDownloadToken(ctx context.Context, serialNumber string) (tokenString string, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method get_cert_download_token for cert took %s to complete", time.Since(begin))
 		if err != nil {
@@ -70,7 +70,19 @@ func (lm *loggingMiddleware) RetrieveCertDownloadToken(ctx context.Context, seri
 		}
 		lm.logger.Info(message)
 	}(time.Now())
-	return lm.svc.RetrieveCertDownloadToken(ctx, serialNumber...)
+	return lm.svc.RetrieveCertDownloadToken(ctx, serialNumber)
+}
+
+func (lm *loggingMiddleware) RetrieveCAToken(ctx context.Context) (tokenString string, err error) {
+	defer func(begin time.Time) {
+		message := fmt.Sprintf("Method get_cert_download_token for cert took %s to complete", time.Since(begin))
+		if err != nil {
+			lm.logger.Warn(fmt.Sprintf("%s with error: %s.", message, err))
+			return
+		}
+		lm.logger.Info(message)
+	}(time.Now())
+	return lm.svc.RetrieveCAToken(ctx)
 }
 
 func (lm *loggingMiddleware) IssueCert(ctx context.Context, entityID, ttl string, ipAddrs []string, options certs.SubjectOptions) (cert certs.Certificate, err error) {
@@ -97,7 +109,7 @@ func (lm *loggingMiddleware) ListCerts(ctx context.Context, pm certs.PageMetadat
 	return lm.svc.ListCerts(ctx, pm)
 }
 
-func (lm *loggingMiddleware) ViewCert(ctx context.Context, serialNumber ...string) (cert certs.Certificate, err error) {
+func (lm *loggingMiddleware) ViewCert(ctx context.Context, serialNumber string) (cert certs.Certificate, err error) {
 	defer func(begin time.Time) {
 		message := fmt.Sprintf("Method view_cert for serial number %s took %s to complete", serialNumber, time.Since(begin))
 		if err != nil {
@@ -106,7 +118,7 @@ func (lm *loggingMiddleware) ViewCert(ctx context.Context, serialNumber ...strin
 		}
 		lm.logger.Info(message)
 	}(time.Now())
-	return lm.svc.ViewCert(ctx, serialNumber...)
+	return lm.svc.ViewCert(ctx, serialNumber)
 }
 
 func (lm *loggingMiddleware) OCSP(ctx context.Context, serialNumber string) (cert *certs.Certificate, ocspStatus int, rootCACert *x509.Certificate, err error) {

--- a/api/metrics.go
+++ b/api/metrics.go
@@ -53,13 +53,22 @@ func (mm *metricsMiddleware) RevokeCert(ctx context.Context, serialNumber string
 	return mm.svc.RevokeCert(ctx, serialNumber)
 }
 
-func (mm *metricsMiddleware) RetrieveCertDownloadToken(ctx context.Context, serialNumber ...string) (string, error) {
+func (mm *metricsMiddleware) RetrieveCertDownloadToken(ctx context.Context, serialNumber string) (string, error) {
 	defer func(begin time.Time) {
 		mm.counter.With("method", "get_certificate_download_token").Add(1)
 		mm.latency.With("method", "get_certificate_download_token").Observe(time.Since(begin).Seconds())
 	}(time.Now())
 
-	return mm.svc.RetrieveCertDownloadToken(ctx, serialNumber...)
+	return mm.svc.RetrieveCertDownloadToken(ctx, serialNumber)
+}
+
+func (mm *metricsMiddleware) RetrieveCAToken(ctx context.Context) (string, error) {
+	defer func(begin time.Time) {
+		mm.counter.With("method", "get_CA_token").Add(1)
+		mm.latency.With("method", "get_CA_token").Observe(time.Since(begin).Seconds())
+	}(time.Now())
+
+	return mm.svc.RetrieveCAToken(ctx)
 }
 
 func (mm *metricsMiddleware) IssueCert(ctx context.Context, entityID, ttl string, ipAddrs []string, options certs.SubjectOptions) (certs.Certificate, error) {
@@ -78,13 +87,13 @@ func (mm *metricsMiddleware) ListCerts(ctx context.Context, pm certs.PageMetadat
 	return mm.svc.ListCerts(ctx, pm)
 }
 
-func (mm *metricsMiddleware) ViewCert(ctx context.Context, serialNumber ...string) (certs.Certificate, error) {
+func (mm *metricsMiddleware) ViewCert(ctx context.Context, serialNumber string) (certs.Certificate, error) {
 	defer func(begin time.Time) {
 		mm.counter.With("method", "view_certificate").Add(1)
 		mm.latency.With("method", "view_certificate").Observe(time.Since(begin).Seconds())
 	}(time.Now())
 
-	return mm.svc.ViewCert(ctx, serialNumber...)
+	return mm.svc.ViewCert(ctx, serialNumber)
 }
 
 func (mm *metricsMiddleware) OCSP(ctx context.Context, serialNumber string) (*certs.Certificate, int, *x509.Certificate, error) {

--- a/api/metrics.go
+++ b/api/metrics.go
@@ -53,12 +53,13 @@ func (mm *metricsMiddleware) RevokeCert(ctx context.Context, serialNumber string
 	return mm.svc.RevokeCert(ctx, serialNumber)
 }
 
-func (mm *metricsMiddleware) RetrieveCertDownloadToken(ctx context.Context, serialNumber string) (string, error) {
+func (mm *metricsMiddleware) RetrieveCertDownloadToken(ctx context.Context, serialNumber ...string) (string, error) {
 	defer func(begin time.Time) {
 		mm.counter.With("method", "get_certificate_download_token").Add(1)
 		mm.latency.With("method", "get_certificate_download_token").Observe(time.Since(begin).Seconds())
 	}(time.Now())
-	return mm.svc.RetrieveCertDownloadToken(ctx, serialNumber)
+
+	return mm.svc.RetrieveCertDownloadToken(ctx, serialNumber...)
 }
 
 func (mm *metricsMiddleware) IssueCert(ctx context.Context, entityID, ttl string, ipAddrs []string, options certs.SubjectOptions) (certs.Certificate, error) {
@@ -77,12 +78,13 @@ func (mm *metricsMiddleware) ListCerts(ctx context.Context, pm certs.PageMetadat
 	return mm.svc.ListCerts(ctx, pm)
 }
 
-func (mm *metricsMiddleware) ViewCert(ctx context.Context, serialNumber string) (certs.Certificate, error) {
+func (mm *metricsMiddleware) ViewCert(ctx context.Context, serialNumber ...string) (certs.Certificate, error) {
 	defer func(begin time.Time) {
 		mm.counter.With("method", "view_certificate").Add(1)
 		mm.latency.With("method", "view_certificate").Observe(time.Since(begin).Seconds())
 	}(time.Now())
-	return mm.svc.ViewCert(ctx, serialNumber)
+
+	return mm.svc.ViewCert(ctx, serialNumber...)
 }
 
 func (mm *metricsMiddleware) OCSP(ctx context.Context, serialNumber string) (*certs.Certificate, int, *x509.Certificate, error) {
@@ -107,4 +109,12 @@ func (mm *metricsMiddleware) GenerateCRL(ctx context.Context, caType certs.CertT
 		mm.latency.With("method", "generate_crl").Observe(time.Since(begin).Seconds())
 	}(time.Now())
 	return mm.svc.GenerateCRL(ctx, caType)
+}
+
+func (mm *metricsMiddleware) GetSigningCA(ctx context.Context, token string) (certs.Certificate, error) {
+	defer func(begin time.Time) {
+		mm.counter.With("method", "get_signing_ca").Add(1)
+		mm.latency.With("method", "get_signing_ca").Observe(time.Since(begin).Seconds())
+	}(time.Now())
+	return mm.svc.GetSigningCA(ctx, token)
 }

--- a/certs.go
+++ b/certs.go
@@ -43,13 +43,18 @@ type Service interface {
 	RetrieveCert(ctx context.Context, token, serialNumber string) (Certificate, []byte, error)
 
 	// ViewCert retrieves a certificate record from the database.
-	ViewCert(ctx context.Context, serialNumber ...string) (Certificate, error)
+	ViewCert(ctx context.Context, serialNumber string) (Certificate, error)
 
 	// ListCerts retrieves the certificates from the database while applying filters.
 	ListCerts(ctx context.Context, pm PageMetadata) (CertificatePage, error)
 
-	// RetrieveCertDownloadToken retrieves a certificate download token.
-	RetrieveCertDownloadToken(ctx context.Context, serialNumber ...string) (string, error)
+	// RetrieveCertDownloadToken generates a certificate download token.
+	// The token is needed to download the client certificate.
+	RetrieveCertDownloadToken(ctx context.Context, serialNumber string) (string, error)
+
+	// RetrieveCAToken generates a CA download and view token.
+	// The token is needed to view and download the CA certificate.
+	RetrieveCAToken(ctx context.Context) (string, error)
 
 	// IssueCert issues a certificate from the database.
 	IssueCert(ctx context.Context, entityID, ttl string, ipAddrs []string, option SubjectOptions) (Certificate, error)

--- a/certs.go
+++ b/certs.go
@@ -40,16 +40,16 @@ type Service interface {
 	RevokeCert(ctx context.Context, serialNumber string) error
 
 	// RetrieveCert retrieves a certificate record from the database.
-	RetrieveCert(ctx context.Context, token string, serialNumber string) (Certificate, []byte, error)
+	RetrieveCert(ctx context.Context, token, serialNumber string) (Certificate, []byte, error)
 
 	// ViewCert retrieves a certificate record from the database.
-	ViewCert(ctx context.Context, serialNumber string) (Certificate, error)
+	ViewCert(ctx context.Context, serialNumber ...string) (Certificate, error)
 
 	// ListCerts retrieves the certificates from the database while applying filters.
 	ListCerts(ctx context.Context, pm PageMetadata) (CertificatePage, error)
 
 	// RetrieveCertDownloadToken retrieves a certificate download token.
-	RetrieveCertDownloadToken(ctx context.Context, serialNumber string) (string, error)
+	RetrieveCertDownloadToken(ctx context.Context, serialNumber ...string) (string, error)
 
 	// IssueCert issues a certificate from the database.
 	IssueCert(ctx context.Context, entityID, ttl string, ipAddrs []string, option SubjectOptions) (Certificate, error)
@@ -60,8 +60,11 @@ type Service interface {
 	// GetEntityID retrieves the entity ID for a certificate.
 	GetEntityID(ctx context.Context, serialNumber string) (string, error)
 
-	// GenerateCRL creates
+	// GenerateCRL creates cert revocation list.
 	GenerateCRL(ctx context.Context, caType CertType) ([]byte, error)
+
+	// Retrieves the signing CA.
+	GetSigningCA(ctx context.Context, token string) (Certificate, error)
 }
 
 type Repository interface {

--- a/cli/certs.go
+++ b/cli/certs.go
@@ -139,7 +139,7 @@ var cmdCerts = []cobra.Command{
 		},
 	},
 	{
-		Use:   "view <serial_number> ",
+		Use:   "view <serial_number>",
 		Short: "View certificate",
 		Long:  `Views a certificate for a given serial number.`,
 		Run: func(cmd *cobra.Command, args []string) {
@@ -153,6 +153,57 @@ var cmdCerts = []cobra.Command{
 				return
 			}
 			logJSONCmd(*cmd, cert)
+		},
+	},
+	{
+		Use:   "view-ca <token>",
+		Short: "View-ca certificate",
+		Long:  `Views ca certificate key with a given token.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) != 1 {
+				logUsageCmd(*cmd, cmd.Use)
+				return
+			}
+			cert, err := sdk.ViewCA(args[0])
+			if err != nil {
+				logErrorCmd(*cmd, err)
+				return
+			}
+			logJSONCmd(*cmd, cert)
+		},
+	},
+	{
+		Use:   "download-ca <token>",
+		Short: "Download signing CA",
+		Long:  `Download intermediate cert and ca with a given token.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) != 1 {
+				logUsageCmd(*cmd, cmd.Use)
+				return
+			}
+			bundle, err := sdk.DownloadCA(args[0])
+			if err != nil {
+				logErrorCmd(*cmd, err)
+				return
+			}
+			logSaveCAFiles(*cmd, bundle)
+		},
+	},
+	{
+		Use:   "token-ca",
+		Short: "Get CA token",
+		Long:  `Gets a download token for CA.`,
+		Run: func(cmd *cobra.Command, args []string) {
+			if len(args) != 0 {
+				logUsageCmd(*cmd, cmd.Use)
+				return
+			}
+			token, err := sdk.GetCAToken()
+			if err != nil {
+				logErrorCmd(*cmd, err)
+				return
+			}
+			logJSONCmd(*cmd, token)
 		},
 	},
 }

--- a/cli/certs_test.go
+++ b/cli/certs_test.go
@@ -21,13 +21,16 @@ import (
 )
 
 const (
-	revokeCmd   = "revoke"
-	issueCmd    = "issue"
-	renewCmd    = "renew"
-	listCmd     = "get"
-	tokenCmd    = "token"
-	downloadCmd = "download"
-	all         = "all"
+	revokeCmd     = "revoke"
+	issueCmd      = "issue"
+	renewCmd      = "renew"
+	listCmd       = "get"
+	tokenCmd      = "token"
+	downloadCmd   = "download"
+	all           = "all"
+	downloadCACmd = "download-ca"
+	CATokenCmd    = "token-ca"
+	viewCACmd     = "view-ca"
 )
 
 var (
@@ -35,6 +38,7 @@ var (
 	id           = "5b4c9ee3-e719-4a0a-9ee5-354932c5e6a4"
 	commonName   = "test-name"
 	extraArg     = "extra-arg"
+	token        = "token"
 )
 
 func TestIssueCertCmd(t *testing.T) {
@@ -395,7 +399,6 @@ func TestDownloadCertCmd(t *testing.T) {
 	certCmd := cli.NewCertsCmd()
 	rootCmd := setFlags(certCmd)
 
-	token := "token"
 	cases := []struct {
 		desc          string
 		args          []string
@@ -453,6 +456,200 @@ func TestDownloadCertCmd(t *testing.T) {
 				assert.True(t, strings.Contains(out, "Saved key.pem"), fmt.Sprintf("%s invalid output: %s", tc.desc, out))
 				assert.True(t, strings.Contains(out, "Saved cert.pem"), fmt.Sprintf("%s invalid output: %s", tc.desc, out))
 				assert.True(t, strings.Contains(out, "Saved ca.pem"), fmt.Sprintf("%s invalid output: %s", tc.desc, out))
+			case usageLog:
+				assert.False(t, strings.Contains(out, rootCmd.Use), fmt.Sprintf("%s invalid usage: %s", tc.desc, out))
+			case errLog:
+				assert.Equal(t, tc.errLogMessage, out, fmt.Sprintf("%s unexpected error response: expected %s got errLogMessage:%s", tc.desc, tc.errLogMessage, out))
+			}
+			sdkCall.Unset()
+		})
+	}
+}
+
+func TestGetCATokenCmd(t *testing.T) {
+	sdkMock := new(sdkmocks.MockSDK)
+	cli.SetSDK(sdkMock)
+	certCmd := cli.NewCertsCmd()
+	rootCmd := setFlags(certCmd)
+
+	tk := "ca1121f5-d66a-44c9-bf3c-d267498a0f3d"
+
+	var token sdk.Token
+	cases := []struct {
+		desc          string
+		args          []string
+		sdkErr        errors.SDKError
+		errLogMessage string
+		logType       outputLog
+		token         sdk.Token
+	}{
+		{
+			desc:    "get CA token successfully",
+			args:    []string{},
+			logType: entityLog,
+			token:   sdk.Token{Token: tk},
+		},
+		{
+			desc: "get CA token with invalid args",
+			args: []string{
+				extraArg,
+			},
+			logType: usageLog,
+		},
+		{
+			desc:          "get CA token failed",
+			args:          []string{},
+			sdkErr:        errors.NewSDKErrorWithStatus(certs.ErrGetToken, http.StatusUnprocessableEntity),
+			errLogMessage: fmt.Sprintf("\nerror: %s\n\n", errors.NewSDKErrorWithStatus(certs.ErrGetToken, http.StatusUnprocessableEntity)),
+			logType:       errLog,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			sdkCall := sdkMock.On("GetCAToken").Return(tc.token, tc.sdkErr)
+			out := executeCommand(t, rootCmd, append([]string{CATokenCmd}, tc.args...)...)
+
+			switch tc.logType {
+			case errLog:
+				assert.Equal(t, tc.errLogMessage, out, fmt.Sprintf("%s unexpected error response: expected %s got errLogMessage:%s", tc.desc, tc.errLogMessage, out))
+			case usageLog:
+				assert.False(t, strings.Contains(out, rootCmd.Use), fmt.Sprintf("%s invalid usage: %s", tc.desc, out))
+			case entityLog:
+				err := json.Unmarshal([]byte(out), &token)
+				if err != nil {
+					t.Fatalf("Failed to unmarshal JSON: %v", err)
+				}
+				assert.Equal(t, tc.token, token, fmt.Sprintf("%v unexpected response, expected: %v, got: %v", tc.desc, tc.token, token))
+			}
+			sdkCall.Unset()
+		})
+	}
+}
+
+func TestDownloadCACmd(t *testing.T) {
+	sdkMock := new(sdkmocks.MockSDK)
+	cli.SetSDK(sdkMock)
+	certCmd := cli.NewCertsCmd()
+	rootCmd := setFlags(certCmd)
+
+	cases := []struct {
+		desc          string
+		args          []string
+		sdkErr        errors.SDKError
+		errLogMessage string
+		logMessage    string
+		logType       outputLog
+		certBundle    sdk.CertificateBundle
+	}{
+		{
+			desc: "download CA successfully",
+			args: []string{
+				token,
+			},
+			logType: entityLog,
+			certBundle: sdk.CertificateBundle{
+				Certificate: []byte("certificate"),
+				PrivateKey:  []byte("privatekey"),
+			},
+			logMessage: "Saved ca.pem\nSaved cert.pem\nSaved key.pem\n\nAll certificate files have been saved successfully.\n",
+		},
+		{
+			desc: "download CA with invalid args",
+			args: []string{
+				token,
+				extraArg,
+			},
+			logType: usageLog,
+		},
+		{
+			desc: "download cert failed",
+			args: []string{
+				token,
+			},
+			sdkErr:        errors.NewSDKErrorWithStatus(certs.ErrUpdateEntity, http.StatusUnprocessableEntity),
+			errLogMessage: fmt.Sprintf("\nerror: %s\n\n", errors.NewSDKErrorWithStatus(certs.ErrUpdateEntity, http.StatusUnprocessableEntity)),
+			logType:       errLog,
+			certBundle:    sdk.CertificateBundle{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			defer func() {
+				cleanupFiles(t, []string{"ca.key", "ca.crt"})
+			}()
+			sdkCall := sdkMock.On("DownloadCA", mock.Anything, mock.Anything).Return(tc.certBundle, tc.sdkErr)
+			out := executeCommand(t, rootCmd, append([]string{downloadCACmd}, tc.args...)...)
+			switch tc.logType {
+			case entityLog:
+				assert.True(t, strings.Contains(out, "Saved ca.crt"), fmt.Sprintf("%s invalid output: %s", tc.desc, out))
+				assert.True(t, strings.Contains(out, "Saved ca.key"), fmt.Sprintf("%s invalid output: %s", tc.desc, out))
+			case usageLog:
+				assert.False(t, strings.Contains(out, rootCmd.Use), fmt.Sprintf("%s invalid usage: %s", tc.desc, out))
+			case errLog:
+				assert.Equal(t, tc.errLogMessage, out, fmt.Sprintf("%s unexpected error response: expected %s got errLogMessage:%s", tc.desc, tc.errLogMessage, out))
+			}
+			sdkCall.Unset()
+		})
+	}
+}
+
+func TestViewCACmd(t *testing.T) {
+	sdkMock := new(sdkmocks.MockSDK)
+	cli.SetSDK(sdkMock)
+	certCmd := cli.NewCertsCmd()
+	rootCmd := setFlags(certCmd)
+
+	var cert sdk.Certificate
+	cases := []struct {
+		desc          string
+		args          []string
+		sdkErr        errors.SDKError
+		errLogMessage string
+		logType       outputLog
+		cert          sdk.Certificate
+	}{
+		{
+			desc: "view cert successfully",
+			args: []string{
+				token,
+			},
+			logType: entityLog,
+			cert: sdk.Certificate{
+				Certificate: "certificate",
+				Key:         "privatekey",
+			},
+		},
+		{
+			desc: "view cert with invalid args",
+			args: []string{
+				token,
+				extraArg,
+			},
+			logType: usageLog,
+		},
+		{
+			desc: "view cert failed",
+			args: []string{
+				token,
+			},
+			sdkErr:        errors.NewSDKErrorWithStatus(certs.ErrUpdateEntity, http.StatusUnprocessableEntity),
+			errLogMessage: fmt.Sprintf("\nerror: %s\n\n", errors.NewSDKErrorWithStatus(certs.ErrUpdateEntity, http.StatusUnprocessableEntity)),
+			logType:       errLog,
+			cert:          sdk.Certificate{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			sdkCall := sdkMock.On("ViewCA", mock.Anything).Return(tc.cert, tc.sdkErr)
+			out := executeCommand(t, rootCmd, append([]string{viewCACmd}, tc.args...)...)
+			switch tc.logType {
+			case entityLog:
+				err := json.Unmarshal([]byte(out), &cert)
+				assert.Nil(t, err)
+				assert.Equal(t, tc.cert, cert, fmt.Sprintf("%s unexpected response: expected: %v, got: %v", tc.desc, tc.cert, cert))
 			case usageLog:
 				assert.False(t, strings.Contains(out, rootCmd.Use), fmt.Sprintf("%s invalid usage: %s", tc.desc, out))
 			case errLog:

--- a/cli/utils.go
+++ b/cli/utils.go
@@ -82,6 +82,23 @@ func logSaveCertFiles(cmd cobra.Command, certBundle ctxsdk.CertificateBundle) {
 	fmt.Fprintf(cmd.OutOrStdout(), "\nAll certificate files have been saved successfully.\n")
 }
 
+func logSaveCAFiles(cmd cobra.Command, certBundle ctxsdk.CertificateBundle) {
+	files := map[string][]byte{
+		"ca.crt": certBundle.Certificate,
+		"ca.key": certBundle.PrivateKey,
+	}
+
+	for filename, content := range files {
+		err := saveToFile(filename, content)
+		if err != nil {
+			logErrorCmd(cmd, err)
+			return
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "Saved %s\n", filename)
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "\nAll certificate files have been saved successfully.\n")
+}
+
 func saveToFile(filename string, content []byte) error {
 	cwd, err := os.Getwd()
 	if err != nil {

--- a/mocks/service.go
+++ b/mocks/service.go
@@ -144,6 +144,63 @@ func (_c *MockService_GetEntityID_Call) RunAndReturn(run func(context.Context, s
 	return _c
 }
 
+// GetSigningCA provides a mock function with given fields: ctx, token
+func (_m *MockService) GetSigningCA(ctx context.Context, token string) (certs.Certificate, error) {
+	ret := _m.Called(ctx, token)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetSigningCA")
+	}
+
+	var r0 certs.Certificate
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) (certs.Certificate, error)); ok {
+		return rf(ctx, token)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string) certs.Certificate); ok {
+		r0 = rf(ctx, token)
+	} else {
+		r0 = ret.Get(0).(certs.Certificate)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, token)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockService_GetSigningCA_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetSigningCA'
+type MockService_GetSigningCA_Call struct {
+	*mock.Call
+}
+
+// GetSigningCA is a helper method to define mock.On call
+//   - ctx context.Context
+//   - token string
+func (_e *MockService_Expecter) GetSigningCA(ctx interface{}, token interface{}) *MockService_GetSigningCA_Call {
+	return &MockService_GetSigningCA_Call{Call: _e.mock.On("GetSigningCA", ctx, token)}
+}
+
+func (_c *MockService_GetSigningCA_Call) Run(run func(ctx context.Context, token string)) *MockService_GetSigningCA_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *MockService_GetSigningCA_Call) Return(_a0 certs.Certificate, _a1 error) *MockService_GetSigningCA_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockService_GetSigningCA_Call) RunAndReturn(run func(context.Context, string) (certs.Certificate, error)) *MockService_GetSigningCA_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // IssueCert provides a mock function with given fields: ctx, entityID, ttl, ipAddrs, option
 func (_m *MockService) IssueCert(ctx context.Context, entityID string, ttl string, ipAddrs []string, option certs.SubjectOptions) (certs.Certificate, error) {
 	ret := _m.Called(ctx, entityID, ttl, ipAddrs, option)
@@ -451,8 +508,15 @@ func (_c *MockService_RetrieveCert_Call) RunAndReturn(run func(context.Context, 
 }
 
 // RetrieveCertDownloadToken provides a mock function with given fields: ctx, serialNumber
-func (_m *MockService) RetrieveCertDownloadToken(ctx context.Context, serialNumber string) (string, error) {
-	ret := _m.Called(ctx, serialNumber)
+func (_m *MockService) RetrieveCertDownloadToken(ctx context.Context, serialNumber ...string) (string, error) {
+	_va := make([]interface{}, len(serialNumber))
+	for _i := range serialNumber {
+		_va[_i] = serialNumber[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	if len(ret) == 0 {
 		panic("no return value specified for RetrieveCertDownloadToken")
@@ -460,17 +524,17 @@ func (_m *MockService) RetrieveCertDownloadToken(ctx context.Context, serialNumb
 
 	var r0 string
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) (string, error)); ok {
-		return rf(ctx, serialNumber)
+	if rf, ok := ret.Get(0).(func(context.Context, ...string) (string, error)); ok {
+		return rf(ctx, serialNumber...)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string) string); ok {
-		r0 = rf(ctx, serialNumber)
+	if rf, ok := ret.Get(0).(func(context.Context, ...string) string); ok {
+		r0 = rf(ctx, serialNumber...)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = rf(ctx, serialNumber)
+	if rf, ok := ret.Get(1).(func(context.Context, ...string) error); ok {
+		r1 = rf(ctx, serialNumber...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -485,14 +549,21 @@ type MockService_RetrieveCertDownloadToken_Call struct {
 
 // RetrieveCertDownloadToken is a helper method to define mock.On call
 //   - ctx context.Context
-//   - serialNumber string
-func (_e *MockService_Expecter) RetrieveCertDownloadToken(ctx interface{}, serialNumber interface{}) *MockService_RetrieveCertDownloadToken_Call {
-	return &MockService_RetrieveCertDownloadToken_Call{Call: _e.mock.On("RetrieveCertDownloadToken", ctx, serialNumber)}
+//   - serialNumber ...string
+func (_e *MockService_Expecter) RetrieveCertDownloadToken(ctx interface{}, serialNumber ...interface{}) *MockService_RetrieveCertDownloadToken_Call {
+	return &MockService_RetrieveCertDownloadToken_Call{Call: _e.mock.On("RetrieveCertDownloadToken",
+		append([]interface{}{ctx}, serialNumber...)...)}
 }
 
-func (_c *MockService_RetrieveCertDownloadToken_Call) Run(run func(ctx context.Context, serialNumber string)) *MockService_RetrieveCertDownloadToken_Call {
+func (_c *MockService_RetrieveCertDownloadToken_Call) Run(run func(ctx context.Context, serialNumber ...string)) *MockService_RetrieveCertDownloadToken_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string))
+		variadicArgs := make([]string, len(args)-1)
+		for i, a := range args[1:] {
+			if a != nil {
+				variadicArgs[i] = a.(string)
+			}
+		}
+		run(args[0].(context.Context), variadicArgs...)
 	})
 	return _c
 }
@@ -502,7 +573,7 @@ func (_c *MockService_RetrieveCertDownloadToken_Call) Return(_a0 string, _a1 err
 	return _c
 }
 
-func (_c *MockService_RetrieveCertDownloadToken_Call) RunAndReturn(run func(context.Context, string) (string, error)) *MockService_RetrieveCertDownloadToken_Call {
+func (_c *MockService_RetrieveCertDownloadToken_Call) RunAndReturn(run func(context.Context, ...string) (string, error)) *MockService_RetrieveCertDownloadToken_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -555,8 +626,15 @@ func (_c *MockService_RevokeCert_Call) RunAndReturn(run func(context.Context, st
 }
 
 // ViewCert provides a mock function with given fields: ctx, serialNumber
-func (_m *MockService) ViewCert(ctx context.Context, serialNumber string) (certs.Certificate, error) {
-	ret := _m.Called(ctx, serialNumber)
+func (_m *MockService) ViewCert(ctx context.Context, serialNumber ...string) (certs.Certificate, error) {
+	_va := make([]interface{}, len(serialNumber))
+	for _i := range serialNumber {
+		_va[_i] = serialNumber[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ViewCert")
@@ -564,17 +642,17 @@ func (_m *MockService) ViewCert(ctx context.Context, serialNumber string) (certs
 
 	var r0 certs.Certificate
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) (certs.Certificate, error)); ok {
-		return rf(ctx, serialNumber)
+	if rf, ok := ret.Get(0).(func(context.Context, ...string) (certs.Certificate, error)); ok {
+		return rf(ctx, serialNumber...)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string) certs.Certificate); ok {
-		r0 = rf(ctx, serialNumber)
+	if rf, ok := ret.Get(0).(func(context.Context, ...string) certs.Certificate); ok {
+		r0 = rf(ctx, serialNumber...)
 	} else {
 		r0 = ret.Get(0).(certs.Certificate)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = rf(ctx, serialNumber)
+	if rf, ok := ret.Get(1).(func(context.Context, ...string) error); ok {
+		r1 = rf(ctx, serialNumber...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -589,14 +667,21 @@ type MockService_ViewCert_Call struct {
 
 // ViewCert is a helper method to define mock.On call
 //   - ctx context.Context
-//   - serialNumber string
-func (_e *MockService_Expecter) ViewCert(ctx interface{}, serialNumber interface{}) *MockService_ViewCert_Call {
-	return &MockService_ViewCert_Call{Call: _e.mock.On("ViewCert", ctx, serialNumber)}
+//   - serialNumber ...string
+func (_e *MockService_Expecter) ViewCert(ctx interface{}, serialNumber ...interface{}) *MockService_ViewCert_Call {
+	return &MockService_ViewCert_Call{Call: _e.mock.On("ViewCert",
+		append([]interface{}{ctx}, serialNumber...)...)}
 }
 
-func (_c *MockService_ViewCert_Call) Run(run func(ctx context.Context, serialNumber string)) *MockService_ViewCert_Call {
+func (_c *MockService_ViewCert_Call) Run(run func(ctx context.Context, serialNumber ...string)) *MockService_ViewCert_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string))
+		variadicArgs := make([]string, len(args)-1)
+		for i, a := range args[1:] {
+			if a != nil {
+				variadicArgs[i] = a.(string)
+			}
+		}
+		run(args[0].(context.Context), variadicArgs...)
 	})
 	return _c
 }
@@ -606,7 +691,7 @@ func (_c *MockService_ViewCert_Call) Return(_a0 certs.Certificate, _a1 error) *M
 	return _c
 }
 
-func (_c *MockService_ViewCert_Call) RunAndReturn(run func(context.Context, string) (certs.Certificate, error)) *MockService_ViewCert_Call {
+func (_c *MockService_ViewCert_Call) RunAndReturn(run func(context.Context, ...string) (certs.Certificate, error)) *MockService_ViewCert_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/mocks/service.go
+++ b/mocks/service.go
@@ -440,6 +440,62 @@ func (_c *MockService_RenewCert_Call) RunAndReturn(run func(context.Context, str
 	return _c
 }
 
+// RetrieveCAToken provides a mock function with given fields: ctx
+func (_m *MockService) RetrieveCAToken(ctx context.Context) (string, error) {
+	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RetrieveCAToken")
+	}
+
+	var r0 string
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context) (string, error)); ok {
+		return rf(ctx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context) string); ok {
+		r0 = rf(ctx)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockService_RetrieveCAToken_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RetrieveCAToken'
+type MockService_RetrieveCAToken_Call struct {
+	*mock.Call
+}
+
+// RetrieveCAToken is a helper method to define mock.On call
+//   - ctx context.Context
+func (_e *MockService_Expecter) RetrieveCAToken(ctx interface{}) *MockService_RetrieveCAToken_Call {
+	return &MockService_RetrieveCAToken_Call{Call: _e.mock.On("RetrieveCAToken", ctx)}
+}
+
+func (_c *MockService_RetrieveCAToken_Call) Run(run func(ctx context.Context)) *MockService_RetrieveCAToken_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context))
+	})
+	return _c
+}
+
+func (_c *MockService_RetrieveCAToken_Call) Return(_a0 string, _a1 error) *MockService_RetrieveCAToken_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockService_RetrieveCAToken_Call) RunAndReturn(run func(context.Context) (string, error)) *MockService_RetrieveCAToken_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // RetrieveCert provides a mock function with given fields: ctx, token, serialNumber
 func (_m *MockService) RetrieveCert(ctx context.Context, token string, serialNumber string) (certs.Certificate, []byte, error) {
 	ret := _m.Called(ctx, token, serialNumber)
@@ -508,15 +564,8 @@ func (_c *MockService_RetrieveCert_Call) RunAndReturn(run func(context.Context, 
 }
 
 // RetrieveCertDownloadToken provides a mock function with given fields: ctx, serialNumber
-func (_m *MockService) RetrieveCertDownloadToken(ctx context.Context, serialNumber ...string) (string, error) {
-	_va := make([]interface{}, len(serialNumber))
-	for _i := range serialNumber {
-		_va[_i] = serialNumber[_i]
-	}
-	var _ca []interface{}
-	_ca = append(_ca, ctx)
-	_ca = append(_ca, _va...)
-	ret := _m.Called(_ca...)
+func (_m *MockService) RetrieveCertDownloadToken(ctx context.Context, serialNumber string) (string, error) {
+	ret := _m.Called(ctx, serialNumber)
 
 	if len(ret) == 0 {
 		panic("no return value specified for RetrieveCertDownloadToken")
@@ -524,17 +573,17 @@ func (_m *MockService) RetrieveCertDownloadToken(ctx context.Context, serialNumb
 
 	var r0 string
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, ...string) (string, error)); ok {
-		return rf(ctx, serialNumber...)
+	if rf, ok := ret.Get(0).(func(context.Context, string) (string, error)); ok {
+		return rf(ctx, serialNumber)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, ...string) string); ok {
-		r0 = rf(ctx, serialNumber...)
+	if rf, ok := ret.Get(0).(func(context.Context, string) string); ok {
+		r0 = rf(ctx, serialNumber)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, ...string) error); ok {
-		r1 = rf(ctx, serialNumber...)
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, serialNumber)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -549,21 +598,14 @@ type MockService_RetrieveCertDownloadToken_Call struct {
 
 // RetrieveCertDownloadToken is a helper method to define mock.On call
 //   - ctx context.Context
-//   - serialNumber ...string
-func (_e *MockService_Expecter) RetrieveCertDownloadToken(ctx interface{}, serialNumber ...interface{}) *MockService_RetrieveCertDownloadToken_Call {
-	return &MockService_RetrieveCertDownloadToken_Call{Call: _e.mock.On("RetrieveCertDownloadToken",
-		append([]interface{}{ctx}, serialNumber...)...)}
+//   - serialNumber string
+func (_e *MockService_Expecter) RetrieveCertDownloadToken(ctx interface{}, serialNumber interface{}) *MockService_RetrieveCertDownloadToken_Call {
+	return &MockService_RetrieveCertDownloadToken_Call{Call: _e.mock.On("RetrieveCertDownloadToken", ctx, serialNumber)}
 }
 
-func (_c *MockService_RetrieveCertDownloadToken_Call) Run(run func(ctx context.Context, serialNumber ...string)) *MockService_RetrieveCertDownloadToken_Call {
+func (_c *MockService_RetrieveCertDownloadToken_Call) Run(run func(ctx context.Context, serialNumber string)) *MockService_RetrieveCertDownloadToken_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		variadicArgs := make([]string, len(args)-1)
-		for i, a := range args[1:] {
-			if a != nil {
-				variadicArgs[i] = a.(string)
-			}
-		}
-		run(args[0].(context.Context), variadicArgs...)
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -573,7 +615,7 @@ func (_c *MockService_RetrieveCertDownloadToken_Call) Return(_a0 string, _a1 err
 	return _c
 }
 
-func (_c *MockService_RetrieveCertDownloadToken_Call) RunAndReturn(run func(context.Context, ...string) (string, error)) *MockService_RetrieveCertDownloadToken_Call {
+func (_c *MockService_RetrieveCertDownloadToken_Call) RunAndReturn(run func(context.Context, string) (string, error)) *MockService_RetrieveCertDownloadToken_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -626,15 +668,8 @@ func (_c *MockService_RevokeCert_Call) RunAndReturn(run func(context.Context, st
 }
 
 // ViewCert provides a mock function with given fields: ctx, serialNumber
-func (_m *MockService) ViewCert(ctx context.Context, serialNumber ...string) (certs.Certificate, error) {
-	_va := make([]interface{}, len(serialNumber))
-	for _i := range serialNumber {
-		_va[_i] = serialNumber[_i]
-	}
-	var _ca []interface{}
-	_ca = append(_ca, ctx)
-	_ca = append(_ca, _va...)
-	ret := _m.Called(_ca...)
+func (_m *MockService) ViewCert(ctx context.Context, serialNumber string) (certs.Certificate, error) {
+	ret := _m.Called(ctx, serialNumber)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ViewCert")
@@ -642,17 +677,17 @@ func (_m *MockService) ViewCert(ctx context.Context, serialNumber ...string) (ce
 
 	var r0 certs.Certificate
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, ...string) (certs.Certificate, error)); ok {
-		return rf(ctx, serialNumber...)
+	if rf, ok := ret.Get(0).(func(context.Context, string) (certs.Certificate, error)); ok {
+		return rf(ctx, serialNumber)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, ...string) certs.Certificate); ok {
-		r0 = rf(ctx, serialNumber...)
+	if rf, ok := ret.Get(0).(func(context.Context, string) certs.Certificate); ok {
+		r0 = rf(ctx, serialNumber)
 	} else {
 		r0 = ret.Get(0).(certs.Certificate)
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, ...string) error); ok {
-		r1 = rf(ctx, serialNumber...)
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, serialNumber)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -667,21 +702,14 @@ type MockService_ViewCert_Call struct {
 
 // ViewCert is a helper method to define mock.On call
 //   - ctx context.Context
-//   - serialNumber ...string
-func (_e *MockService_Expecter) ViewCert(ctx interface{}, serialNumber ...interface{}) *MockService_ViewCert_Call {
-	return &MockService_ViewCert_Call{Call: _e.mock.On("ViewCert",
-		append([]interface{}{ctx}, serialNumber...)...)}
+//   - serialNumber string
+func (_e *MockService_Expecter) ViewCert(ctx interface{}, serialNumber interface{}) *MockService_ViewCert_Call {
+	return &MockService_ViewCert_Call{Call: _e.mock.On("ViewCert", ctx, serialNumber)}
 }
 
-func (_c *MockService_ViewCert_Call) Run(run func(ctx context.Context, serialNumber ...string)) *MockService_ViewCert_Call {
+func (_c *MockService_ViewCert_Call) Run(run func(ctx context.Context, serialNumber string)) *MockService_ViewCert_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		variadicArgs := make([]string, len(args)-1)
-		for i, a := range args[1:] {
-			if a != nil {
-				variadicArgs[i] = a.(string)
-			}
-		}
-		run(args[0].(context.Context), variadicArgs...)
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -691,7 +719,7 @@ func (_c *MockService_ViewCert_Call) Return(_a0 certs.Certificate, _a1 error) *M
 	return _c
 }
 
-func (_c *MockService_ViewCert_Call) RunAndReturn(run func(context.Context, ...string) (certs.Certificate, error)) *MockService_ViewCert_Call {
+func (_c *MockService_ViewCert_Call) RunAndReturn(run func(context.Context, string) (certs.Certificate, error)) *MockService_ViewCert_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/sdk/certs_test.go
+++ b/sdk/certs_test.go
@@ -570,6 +570,8 @@ func TestDownloadCACert(t *testing.T) {
 			token: token,
 			svcresp: certs.Certificate{
 				SerialNumber: serialNum,
+				Certificate:  []byte("cert"),
+				Key:          []byte("key"),
 			},
 			sdkCert: cert,
 			svcerr:  nil,

--- a/sdk/mocks/sdk.go
+++ b/sdk/mocks/sdk.go
@@ -27,6 +27,64 @@ func (_m *MockSDK) EXPECT() *MockSDK_Expecter {
 	return &MockSDK_Expecter{mock: &_m.Mock}
 }
 
+// DownloadCA provides a mock function with given fields: token
+func (_m *MockSDK) DownloadCA(token string) (sdk.CertificateBundle, errors.SDKError) {
+	ret := _m.Called(token)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DownloadCA")
+	}
+
+	var r0 sdk.CertificateBundle
+	var r1 errors.SDKError
+	if rf, ok := ret.Get(0).(func(string) (sdk.CertificateBundle, errors.SDKError)); ok {
+		return rf(token)
+	}
+	if rf, ok := ret.Get(0).(func(string) sdk.CertificateBundle); ok {
+		r0 = rf(token)
+	} else {
+		r0 = ret.Get(0).(sdk.CertificateBundle)
+	}
+
+	if rf, ok := ret.Get(1).(func(string) errors.SDKError); ok {
+		r1 = rf(token)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(errors.SDKError)
+		}
+	}
+
+	return r0, r1
+}
+
+// MockSDK_DownloadCA_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DownloadCA'
+type MockSDK_DownloadCA_Call struct {
+	*mock.Call
+}
+
+// DownloadCA is a helper method to define mock.On call
+//   - token string
+func (_e *MockSDK_Expecter) DownloadCA(token interface{}) *MockSDK_DownloadCA_Call {
+	return &MockSDK_DownloadCA_Call{Call: _e.mock.On("DownloadCA", token)}
+}
+
+func (_c *MockSDK_DownloadCA_Call) Run(run func(token string)) *MockSDK_DownloadCA_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *MockSDK_DownloadCA_Call) Return(_a0 sdk.CertificateBundle, _a1 errors.SDKError) *MockSDK_DownloadCA_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockSDK_DownloadCA_Call) RunAndReturn(run func(string) (sdk.CertificateBundle, errors.SDKError)) *MockSDK_DownloadCA_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // DownloadCert provides a mock function with given fields: token, serialNumber
 func (_m *MockSDK) DownloadCert(token string, serialNumber string) (sdk.CertificateBundle, errors.SDKError) {
 	ret := _m.Called(token, serialNumber)
@@ -82,6 +140,63 @@ func (_c *MockSDK_DownloadCert_Call) Return(_a0 sdk.CertificateBundle, _a1 error
 }
 
 func (_c *MockSDK_DownloadCert_Call) RunAndReturn(run func(string, string) (sdk.CertificateBundle, errors.SDKError)) *MockSDK_DownloadCert_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetCAToken provides a mock function with given fields:
+func (_m *MockSDK) GetCAToken() (sdk.Token, errors.SDKError) {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetCAToken")
+	}
+
+	var r0 sdk.Token
+	var r1 errors.SDKError
+	if rf, ok := ret.Get(0).(func() (sdk.Token, errors.SDKError)); ok {
+		return rf()
+	}
+	if rf, ok := ret.Get(0).(func() sdk.Token); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(sdk.Token)
+	}
+
+	if rf, ok := ret.Get(1).(func() errors.SDKError); ok {
+		r1 = rf()
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(errors.SDKError)
+		}
+	}
+
+	return r0, r1
+}
+
+// MockSDK_GetCAToken_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetCAToken'
+type MockSDK_GetCAToken_Call struct {
+	*mock.Call
+}
+
+// GetCAToken is a helper method to define mock.On call
+func (_e *MockSDK_Expecter) GetCAToken() *MockSDK_GetCAToken_Call {
+	return &MockSDK_GetCAToken_Call{Call: _e.mock.On("GetCAToken")}
+}
+
+func (_c *MockSDK_GetCAToken_Call) Run(run func()) *MockSDK_GetCAToken_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockSDK_GetCAToken_Call) Return(_a0 sdk.Token, _a1 errors.SDKError) *MockSDK_GetCAToken_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockSDK_GetCAToken_Call) RunAndReturn(run func() (sdk.Token, errors.SDKError)) *MockSDK_GetCAToken_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -415,6 +530,64 @@ func (_c *MockSDK_RevokeCert_Call) Return(_a0 errors.SDKError) *MockSDK_RevokeCe
 }
 
 func (_c *MockSDK_RevokeCert_Call) RunAndReturn(run func(string) errors.SDKError) *MockSDK_RevokeCert_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ViewCA provides a mock function with given fields: token
+func (_m *MockSDK) ViewCA(token string) (sdk.Certificate, errors.SDKError) {
+	ret := _m.Called(token)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ViewCA")
+	}
+
+	var r0 sdk.Certificate
+	var r1 errors.SDKError
+	if rf, ok := ret.Get(0).(func(string) (sdk.Certificate, errors.SDKError)); ok {
+		return rf(token)
+	}
+	if rf, ok := ret.Get(0).(func(string) sdk.Certificate); ok {
+		r0 = rf(token)
+	} else {
+		r0 = ret.Get(0).(sdk.Certificate)
+	}
+
+	if rf, ok := ret.Get(1).(func(string) errors.SDKError); ok {
+		r1 = rf(token)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(errors.SDKError)
+		}
+	}
+
+	return r0, r1
+}
+
+// MockSDK_ViewCA_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ViewCA'
+type MockSDK_ViewCA_Call struct {
+	*mock.Call
+}
+
+// ViewCA is a helper method to define mock.On call
+//   - token string
+func (_e *MockSDK_Expecter) ViewCA(token interface{}) *MockSDK_ViewCA_Call {
+	return &MockSDK_ViewCA_Call{Call: _e.mock.On("ViewCA", token)}
+}
+
+func (_c *MockSDK_ViewCA_Call) Run(run func(token string)) *MockSDK_ViewCA_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *MockSDK_ViewCA_Call) Return(_a0 sdk.Certificate, _a1 errors.SDKError) *MockSDK_ViewCA_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockSDK_ViewCA_Call) RunAndReturn(run func(string) (sdk.Certificate, errors.SDKError)) *MockSDK_ViewCA_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -65,12 +65,12 @@ type Token struct {
 }
 
 type Certificate struct {
-	SerialNumber string    `json:"serial_number"`
+	SerialNumber string    `json:"serial_number,omitempty"`
 	Certificate  string    `json:"certificate,omitempty"`
 	Key          string    `json:"key,omitempty"`
-	Revoked      bool      `json:"revoked"`
-	ExpiryTime   time.Time `json:"expiry_time"`
-	EntityID     string    `json:"entity_id"`
+	Revoked      bool      `json:"revoked,omitempty"`
+	ExpiryTime   time.Time `json:"expiry_time,omitempty"`
+	EntityID     string    `json:"entity_id,omitempty"`
 	DownloadUrl  string    `json:"-"`
 }
 
@@ -161,6 +161,27 @@ type SDK interface {
 	//  response, _ := sdk.OCSP("serialNumber")
 	//  fmt.Println(response)
 	OCSP(serialNumber string) (*ocsp.Response, errors.SDKError)
+
+	// ViewCA views the signing certificate
+	//
+	// example:
+	//  response, _ := sdk.ViewCA(token)
+	//  fmt.Println(response)
+	ViewCA(token string) (Certificate, errors.SDKError)
+
+	// DownloadCA downloads the signing certificate
+	//
+	// example:
+	//  response, _ := sdk.DownloadCA(token)
+	//  fmt.Println(response)
+	DownloadCA(token string) (CertificateBundle, errors.SDKError)
+
+	// GetCAToken get token for viewing and downloading CA
+	//
+	// example:
+	//  response, _ := sdk.GetCAToken()
+	//  fmt.Println(response)
+	GetCAToken() (Token, errors.SDKError)
 }
 
 func (sdk mgSDK) IssueCert(entityID, ttl string, ipAddrs []string, opts Options) (Certificate, errors.SDKError) {
@@ -296,6 +317,76 @@ func (sdk mgSDK) OCSP(serialNumber string) (*ocsp.Response, errors.SDKError) {
 		return &ocsp.Response{}, errors.NewSDKError(err)
 	}
 	return ocspResp, nil
+}
+
+func (sdk mgSDK) ViewCA(token string) (Certificate, errors.SDKError) {
+	pm := PageMetadata{
+		Token: token,
+	}
+	url, err := sdk.withQueryParams(sdk.certsURL, fmt.Sprintf("%s/view-ca", certsEndpoint), pm)
+	if err != nil {
+		return Certificate{}, errors.NewSDKError(err)
+	}
+
+	_, body, sdkerr := sdk.processRequest(http.MethodGet, url, nil, nil, http.StatusOK)
+	if sdkerr != nil {
+		return Certificate{}, sdkerr
+	}
+
+	var cert Certificate
+	if err := json.Unmarshal(body, &cert); err != nil {
+		return Certificate{}, errors.NewSDKError(err)
+	}
+	return cert, nil
+}
+
+func (sdk mgSDK) DownloadCA(token string) (CertificateBundle, errors.SDKError) {
+	pm := PageMetadata{
+		Token: token,
+	}
+	url, err := sdk.withQueryParams(sdk.certsURL, fmt.Sprintf("%s/download-ca", certsEndpoint), pm)
+	if err != nil {
+		return CertificateBundle{}, errors.NewSDKError(err)
+	}
+	_, body, sdkerr := sdk.processRequest(http.MethodGet, url, nil, nil, http.StatusOK)
+	if sdkerr != nil {
+		return CertificateBundle{}, sdkerr
+	}
+
+	zipReader, err := zip.NewReader(bytes.NewReader(body), int64(len(body)))
+	if err != nil {
+		return CertificateBundle{}, errors.NewSDKError(err)
+	}
+
+	var bundle CertificateBundle
+	for _, file := range zipReader.File {
+		fileContent, err := readZipFile(file)
+		if err != nil {
+			return CertificateBundle{}, errors.NewSDKError(err)
+		}
+		switch file.Name {
+		case "ca.crt":
+			bundle.CA = fileContent
+		case "ca.key":
+			bundle.PrivateKey = fileContent
+		}
+	}
+
+	return bundle, nil
+}
+
+func (sdk mgSDK) GetCAToken() (Token, errors.SDKError) {
+	url := fmt.Sprintf("%s/%s/get-ca/token", sdk.certsURL, certsEndpoint)
+	_, body, sdkerr := sdk.processRequest(http.MethodGet, url, nil, nil, http.StatusOK)
+	if sdkerr != nil {
+		return Token{}, sdkerr
+	}
+
+	var tk Token
+	if err := json.Unmarshal(body, &tk); err != nil {
+		return Token{}, errors.NewSDKError(err)
+	}
+	return tk, nil
 }
 
 func NewSDK(conf Config) SDK {

--- a/sdk/sdk.go
+++ b/sdk/sdk.go
@@ -366,7 +366,7 @@ func (sdk mgSDK) DownloadCA(token string) (CertificateBundle, errors.SDKError) {
 		}
 		switch file.Name {
 		case "ca.crt":
-			bundle.CA = fileContent
+			bundle.Certificate = fileContent
 		case "ca.key":
 			bundle.PrivateKey = fileContent
 		}

--- a/tracing/certs.go
+++ b/tracing/certs.go
@@ -41,10 +41,16 @@ func (tm *tracingMiddleware) RetrieveCert(ctx context.Context, token, serialNumb
 	return tm.svc.RetrieveCert(ctx, token, serialNumber)
 }
 
-func (tm *tracingMiddleware) RetrieveCertDownloadToken(ctx context.Context, serialNumber ...string) (string, error) {
+func (tm *tracingMiddleware) RetrieveCertDownloadToken(ctx context.Context, serialNumber string) (string, error) {
 	ctx, span := tm.tracer.Start(ctx, "get_cert_download_token")
 	defer span.End()
-	return tm.svc.RetrieveCertDownloadToken(ctx, serialNumber...)
+	return tm.svc.RetrieveCertDownloadToken(ctx, serialNumber)
+}
+
+func (tm *tracingMiddleware) RetrieveCAToken(ctx context.Context) (string, error) {
+	ctx, span := tm.tracer.Start(ctx, "get_CA_download_token")
+	defer span.End()
+	return tm.svc.RetrieveCAToken(ctx)
 }
 
 func (tm *tracingMiddleware) IssueCert(ctx context.Context, entityID, ttl string, ipAddrs []string, options certs.SubjectOptions) (certs.Certificate, error) {
@@ -59,10 +65,10 @@ func (tm *tracingMiddleware) ListCerts(ctx context.Context, pm certs.PageMetadat
 	return tm.svc.ListCerts(ctx, pm)
 }
 
-func (s *tracingMiddleware) ViewCert(ctx context.Context, serialNumber ...string) (certs.Certificate, error) {
+func (s *tracingMiddleware) ViewCert(ctx context.Context, serialNumber string) (certs.Certificate, error) {
 	ctx, span := s.tracer.Start(ctx, "view_cert")
 	defer span.End()
-	return s.svc.ViewCert(ctx, serialNumber...)
+	return s.svc.ViewCert(ctx, serialNumber)
 }
 
 func (tm *tracingMiddleware) OCSP(ctx context.Context, serialNumber string) (*certs.Certificate, int, *x509.Certificate, error) {

--- a/tracing/certs.go
+++ b/tracing/certs.go
@@ -41,10 +41,10 @@ func (tm *tracingMiddleware) RetrieveCert(ctx context.Context, token, serialNumb
 	return tm.svc.RetrieveCert(ctx, token, serialNumber)
 }
 
-func (tm *tracingMiddleware) RetrieveCertDownloadToken(ctx context.Context, serialNumber string) (string, error) {
+func (tm *tracingMiddleware) RetrieveCertDownloadToken(ctx context.Context, serialNumber ...string) (string, error) {
 	ctx, span := tm.tracer.Start(ctx, "get_cert_download_token")
 	defer span.End()
-	return tm.svc.RetrieveCertDownloadToken(ctx, serialNumber)
+	return tm.svc.RetrieveCertDownloadToken(ctx, serialNumber...)
 }
 
 func (tm *tracingMiddleware) IssueCert(ctx context.Context, entityID, ttl string, ipAddrs []string, options certs.SubjectOptions) (certs.Certificate, error) {
@@ -59,10 +59,10 @@ func (tm *tracingMiddleware) ListCerts(ctx context.Context, pm certs.PageMetadat
 	return tm.svc.ListCerts(ctx, pm)
 }
 
-func (s *tracingMiddleware) ViewCert(ctx context.Context, serialNumber string) (certs.Certificate, error) {
+func (s *tracingMiddleware) ViewCert(ctx context.Context, serialNumber ...string) (certs.Certificate, error) {
 	ctx, span := s.tracer.Start(ctx, "view_cert")
 	defer span.End()
-	return s.svc.ViewCert(ctx, serialNumber)
+	return s.svc.ViewCert(ctx, serialNumber...)
 }
 
 func (tm *tracingMiddleware) OCSP(ctx context.Context, serialNumber string) (*certs.Certificate, int, *x509.Certificate, error) {
@@ -81,4 +81,10 @@ func (tm *tracingMiddleware) GenerateCRL(ctx context.Context, caType certs.CertT
 	ctx, span := tm.tracer.Start(ctx, "generate_crl")
 	defer span.End()
 	return tm.svc.GenerateCRL(ctx, caType)
+}
+
+func (tm *tracingMiddleware) GetSigningCA(ctx context.Context,token string) (certs.Certificate, error) {
+	ctx, span := tm.tracer.Start(ctx, "get_signing_ca")
+	defer span.End()
+	return tm.svc.GetSigningCA(ctx, token)
 }

--- a/tracing/certs.go
+++ b/tracing/certs.go
@@ -83,7 +83,7 @@ func (tm *tracingMiddleware) GenerateCRL(ctx context.Context, caType certs.CertT
 	return tm.svc.GenerateCRL(ctx, caType)
 }
 
-func (tm *tracingMiddleware) GetSigningCA(ctx context.Context,token string) (certs.Certificate, error) {
+func (tm *tracingMiddleware) GetSigningCA(ctx context.Context, token string) (certs.Certificate, error) {
 	ctx, span := tm.tracer.Start(ctx, "get_signing_ca")
 	defer span.End()
 	return tm.svc.GetSigningCA(ctx, token)


### PR DESCRIPTION
# What type of PR is this?
This is a feature because it adds the following functionality: To retrieve the CA.

## What does this do?
It adds an option to retrieve the signing CA i.e. intermediate CA. This is currently needed for mutual TLS.

## Which issue(s) does this PR fix/relate to?
N/A


## Have you included tests for your changes?
Yes.

## Did you document any new/modified features?
No.


### Notes

<!--Please provide any additional information you feel is important.-->
